### PR TITLE
Fixed _parsePath function to use templateParam parameter instead of global program.template variable.

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -46,7 +46,7 @@ function _emptyResourceCheckHelper(options) {
 
 function _parsePath(templateParam) {
     if (templateParam) {
-        if (program.template.indexOf('.') === 0) {
+        if (templateParam.indexOf('.') === 0) {
             return process.cwd() + '/' + templateParam;
         }
         return templateParam;


### PR DESCRIPTION
This was preventing use of the -r and -i options on the command line if -t was not set. With this change any of the template override options can be used individually.