### PR TITLE
Address issue #111: pretty-print application/json schemas and examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ lib-cov
 *.gz
 *.html
 *.raml
+*.iml
+.idea
 
 pids
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.html
+*.raml
 
 pids
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ lib-cov
 *.out
 *.pid
 *.gz
-*.html
-*.raml
 *.iml
 .idea
 

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -63,9 +63,7 @@ function _prettyPrint(type, schema) {
     if (type === "application/json") {
         return JSON.stringify(JSON.parse(schema), null, " ");
     }
-    else {
-        return schema;
-    }
+    return schema;
 }
 
 /*

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -59,8 +59,13 @@ function _ifTypeIsString(options) {
     }
 }
 
-function _jsonPrettyPrint(options) {
-    return JSON.stringify(JSON.parse(options), null, " ");
+function _prettyPrint(type, schema) {
+    if (type === "application/json") {
+        return JSON.stringify(JSON.parse(schema), null, " ");
+    }
+    else {
+        return schema;
+    }
 }
 
 /*
@@ -128,7 +133,7 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
             md: _markDownHelper,
             lock: _lockIconHelper,
             ifTypeIsString: _ifTypeIsString,
-            jsonPrettyPrint: _jsonPrettyPrint
+            prettyPrint: _prettyPrint
         },
         partials: {
             resource: resourceTemplate,

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -59,6 +59,10 @@ function _ifTypeIsString(options) {
     }
 }
 
+function _jsonPrettyPrint(options) {
+    return JSON.stringify(JSON.parse(options), null, " ");
+}
+
 /*
  The config object can contain the following keys and values:
  template: string or Handlebars object containing the main template (required)
@@ -123,7 +127,8 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
             emptyRequestCheckHelper: _emptyRequestCheckHelper,
             md: _markDownHelper,
             lock: _lockIconHelper,
-            ifTypeIsString: _ifTypeIsString
+            ifTypeIsString: _ifTypeIsString,
+            jsonPrettyPrint: _jsonPrettyPrint
         },
         partials: {
             resource: resourceTemplate,

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -118,12 +118,12 @@
 
                                                 {{#if this.schema}}
                                                     <p><strong>Schema</strong>:</p>
-                                                    <pre><code>{{this.schema}}</code></pre>
+                                                    <pre><code>{{jsonPrettyPrint this.schema}}</code></pre>
                                                 {{/if}}
 
                                                 {{#if this.example}}
                                                     <p><strong>Example</strong>:</p>
-                                                    <pre><code>{{this.example}}</code></pre>
+                                                    <pre><code>{{jsonPrettyPrint this.example}}</code></pre>
                                                 {{/if}}
                                             {{/each}}
                                         {{/if}}
@@ -152,12 +152,12 @@
 
                                                     {{#if this.schema}}
                                                         <p><strong>Schema</strong>:</p>
-                                                        <pre><code>{{this.schema}}</code></pre>
+                                                        <pre><code>{{jsonPrettyPrint this.schema}}</code></pre>
                                                     {{/if}}
 
                                                     {{#if this.example}}
                                                         <p><strong>Example</strong>:</p>
-                                                        <pre><code>{{this.example}}</code></pre>
+                                                        <pre><code>{{jsonPrettyPrint this.example}}</code></pre>
                                                     {{/if}}
                                                 {{/each}}
                                             {{/if}}

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -118,12 +118,12 @@
 
                                                 {{#if this.schema}}
                                                     <p><strong>Schema</strong>:</p>
-                                                    <pre><code>{{jsonPrettyPrint this.schema}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                 {{/if}}
 
                                                 {{#if this.example}}
                                                     <p><strong>Example</strong>:</p>
-                                                    <pre><code>{{jsonPrettyPrint this.example}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.example}}</code></pre>
                                                 {{/if}}
                                             {{/each}}
                                         {{/if}}
@@ -152,12 +152,12 @@
 
                                                     {{#if this.schema}}
                                                         <p><strong>Schema</strong>:</p>
-                                                        <pre><code>{{jsonPrettyPrint this.schema}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                     {{/if}}
 
                                                     {{#if this.example}}
                                                         <p><strong>Example</strong>:</p>
-                                                        <pre><code>{{jsonPrettyPrint this.example}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.example}}</code></pre>
                                                     {{/if}}
                                                 {{/each}}
                                             {{/if}}

--- a/public-cloud-apps-server-conversation-api-conversations.raml.bak
+++ b/public-cloud-apps-server-conversation-api-conversations.raml.bak
@@ -1,0 +1,1141 @@
+#%RAML 0.8
+---
+title: Conversations
+version: v1
+baseUri: /conversation/api/v1/
+documentation:
+    - title: Overview
+      content: |
+           The Conversation service supports an API for the creation of "conversation" resources.  A conversation resource
+           represents either a 1:1 or multiparty text-based chat within which additional content may be shared.
+          
+
+traits:
+    - deprecated:
+        description: TBD
+
+
+/conversation/api/v1/ping:
+    uriParameters:
+    get:
+        description: |
+             Ping and get service health.
+            
+  
+        is: []
+
+        queryParameters:
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:health:ServiceHealth","properties":{"serviceType":{"type":"string","enum":["REQUIRED","OPTIONAL","UNKNOWN"]},"fault":{"type":"boolean"},"optional":{"type":"boolean"},"serviceName":{"type":"string"},"message":{"type":"string"},"unknown":{"type":"boolean"},"serviceState":{"type":"string"},"lastUpdated":{"type":"integer","format":"UTC_MILLISEC"},"offline":{"type":"boolean"},"warn":{"type":"boolean"},"baseUrl":{"type":"string"},"online":{"type":"boolean"},"upstreamServices":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:health:ServiceHealth"}}}}
+                        example: |
+                            {"serviceName": "string","serviceType": "string one of [REQUIRED,OPTIONAL,UNKNOWN]","serviceState": "string one of [ONLINE,OFFLINE,FAULT,WARN,UNKNOWN]","message": "string","lastUpdated": "timestamp","upstreamServices": ["ServiceHealth recursive"],"baseUrl": "url","online": "boolean","offline": "boolean","fault": "boolean","unknown": "boolean","warn": "boolean","optional": "boolean"}
+
+
+/conversation/api/v1/service_health:
+    uriParameters:
+    get:
+        description: |
+             Returns the conversation API server's current health status.
+            
+             NOTE: No authentication is required for this endpoint
+            
+  
+        is: [ deprecated]
+
+        queryParameters:
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:health:ServiceHealth","properties":{"serviceType":{"type":"string","enum":["REQUIRED","OPTIONAL","UNKNOWN"]},"fault":{"type":"boolean"},"optional":{"type":"boolean"},"serviceName":{"type":"string"},"message":{"type":"string"},"unknown":{"type":"boolean"},"serviceState":{"type":"string"},"lastUpdated":{"type":"integer","format":"UTC_MILLISEC"},"offline":{"type":"boolean"},"warn":{"type":"boolean"},"baseUrl":{"type":"string"},"online":{"type":"boolean"},"upstreamServices":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:health:ServiceHealth"}}}}
+                        example: |
+                            {"serviceName": "string","serviceType": "string one of [REQUIRED,OPTIONAL,UNKNOWN]","serviceState": "string one of [ONLINE,OFFLINE,FAULT,WARN,UNKNOWN]","message": "string","lastUpdated": "timestamp","upstreamServices": ["ServiceHealth recursive"],"baseUrl": "url","online": "boolean","offline": "boolean","fault": "boolean","unknown": "boolean","warn": "boolean","optional": "boolean"}
+
+
+/conversation/api/v1/build_info:
+    uriParameters:
+    get:
+        description: |
+             Get The build information
+            
+  
+        is: []
+
+        queryParameters:
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:BuildInfo","properties":{"gitCommit":{"type":"string"},"buildTag":{"type":"string"},"buildUrl":{"type":"string"},"buildId":{"type":"string"},"buildNumber":{"type":"string"},"gitBranch":{"type":"string"}}}
+                        example: |
+                            {"buildNumber": "string","buildId": "string","buildUrl": "string","buildTag": "string","gitCommit": "string","gitBranch": "string"}
+
+
+/conversation/api/v1/transcodeevents:
+    uriParameters:
+    post:
+        description: |
+             Handle Transcode Event
+  
+        is: []
+
+        queryParameters:
+
+        body:
+            application/json:
+                schema: |
+                    {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:event:TranscodeEvent","properties":{"encryptionKeyUrl":{"type":"string"},"transcodedData":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:FileObject","properties":{"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"scr":{"type":"string"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"contentId":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"mimeType":{"type":"string"},"transcodedCollection":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:TranscodedContentObject>","properties":{"items":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:TranscodedContentObject","properties":{"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"uuid":{"type":"string"},"url":{"type":"string"},"content":{"type":"string"},"transcodedContentType":{"type":"string","enum":["BOX_VIEW"]},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"empty":{"type":"boolean"},"contentObject":{"type":"boolean"},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"files":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:FileObject>","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:FileObject"}}}},"comment":{"type":"boolean"},"id":{"type":"string"},"locus":{"type":"boolean"},"event":{"type":"boolean"},"conversation":{"type":"boolean"}}}}}},"version":{"type":"string"},"uuid":{"type":"string"},"url":{"type":"string"},"content":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"contentObject":{"type":"boolean"},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"fileSize":{"type":"integer"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"comment":{"type":"boolean"},"id":{"type":"string"},"locus":{"type":"boolean"},"event":{"type":"boolean"},"conversation":{"type":"boolean"}}},"transcoder":{"type":"string"},"fileVersion":{"type":"string"},"transcodeEventType":{"type":"string","enum":["STARTED","INPROGRESS","ERROR","DONE"]},"fileId":{"type":"string"}}}
+                example: |
+                    {"transcoder": "string","fileId": "string","fileVersion": "string","transcodeEventType": "string one of [STARTED,INPROGRESS,ERROR,DONE]","transcodedData": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","version": "string","contentId": "string","fileSize": "long","mimeType": "string","scr": "string","transcodedCollection": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}},"encryptionKeyUrl": "url"}
+
+        responses:
+            200:
+
+
+/conversation/api/v1/transcodestatus:
+    uriParameters:
+    get:
+  
+        is: []
+
+        queryParameters:
+            id:
+                description: |
+                    
+                type: string
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:TranscodeStatusResponse","properties":{"id":{"type":"string"},"status":{"type":"string"}}}
+                        example: |
+                            {"id": "string","status": "string"}
+
+
+/conversation/api/v1/conversations:
+    uriParameters:
+    get:
+        description: |
+             Getting a list of caller's conversation that meet the criteria specified in the parameters.
+            
+  
+        is: []
+
+        queryParameters:
+            sinceDate:
+                description: |
+                    Last activity time of the conversation is after this date. Date string in unix epoch time format.
+                type: string
+            maxDate:
+                description: |
+                    Last activity time of the conversation is before this date. Date string in unix epoch time format.
+                type: string
+            ackFilter:
+                description: |
+                    Control how read receipt(a.k.a acknowledge) activity to be returned. 3 possible values. "noack": no ack return, "all"(default): no filtering, include everything, "myack": only include read receipt from caller of this api
+                type: string
+
+
+            participantsLimit:
+                description: |
+                    The maximum number of participants return inside conversation participant listing.
+                type: integer
+
+
+            conversationsLimit:
+                description: |
+                    Maximum number of conversation return. Default is 1000.
+                type: integer
+
+
+            activitiesLimit:
+                description: |
+                    Maximum number of activities(non-acknowledge type) return within each conversation. Default is 1000.
+                type: integer
+
+
+            isActive:
+                description: |
+                    If set to true, only include conversation that is not hidden. If set to false , only include conversation that is hidden. Default is to include both.
+                type: boolean
+
+
+            isFavorite:
+                description: |
+                    If set to true, only include conversation that are tagged as favorite. If set to false, only include conversations that are unfavorited. Default is to include both.
+                type: boolean
+
+
+            uuidEntryFormat:
+                description: |
+                    Specified if participant object return should contain both uuid and email format. Default is false, meaning only email as id is retured.
+                type: boolean
+
+
+            personRefresh:
+                description: |
+                    (experimental)control if the person detail in activity need to be refreshed to latest. If person detail got refreshed, person.id will be in UUID format even if original one is email. Default is false.
+                type: boolean
+
+
+            lastViewableActivityOnly:
+                description: |
+                    If set to true, only return last viewable activity within a conversation returned, activitiesLimit parameter is ignored. Default is false;
+                type: boolean
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"}}}}
+                        example: |
+                            {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}
+
+    post:
+        description: |
+             Create a new conversation with initial participants and other optional initial activities.<br/>
+             The initial activities must be presented within the conversation object passed to the server. <br/>
+             Only the following activities is supported for initial conversation creation.
+             <ul>
+             <li> create activity (required as first activity)
+             <li> add participant activity
+             <li> post message activity
+             <li> share content activity
+             <li> unshare content activity
+             </ul>
+             Since it is a new conversation creation, the above activities's target conversation type object can be left blank.
+            
+            
+            
+  
+        is: []
+
+        queryParameters:
+            compact:
+                description: |
+                    If true, conversation created will not include the initial add participant activities(but participant will be associated with the new conversation). <br/>This is helpful when creating a big conversation with lot of initial participants. Default is false.
+                type: boolean
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Conversation","properties":{"clientTempId":{"type":"string"},"convParticipantPropsList":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ConvParticipantProps"}},"activity":{"type":"boolean"},"displayName":{"type":"string"},"encryptionKeyConvTitleUrl":{"type":"string"},"uuid":{"type":"string"},"content":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"locusUrl":{"type":"string"},"id":{"type":"string"},"event":{"type":"boolean"},"conversation":{"type":"boolean"},"participants":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"defaultActivityEncryptionKeyUrl":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"url":{"type":"string"},"tags":{"type":"array","items":{"type":"string","enum":["MUTED","HIDDEN","ONE_ON_ONE","FAVORITE"]}},"contentObject":{"type":"boolean"},"activities":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Activity>"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                        example: |
+                            {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","participants": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"activities": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"tags": ["string one of [MUTED,HIDDEN,ONE_ON_ONE,FAVORITE]"],"convParticipantPropsList": [{"isOfflineNotificationDisabled": "boolean","seenActivityUUID": "uuid","participant": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"},"seenActivityTime": "long","participantId": "uuid","participantEmailAddress": {}}],"clientTempId": "string","locusUrl": "url","defaultActivityEncryptionKeyUrl": "url","encryptionKeyConvTitleUrl": "url"}
+
+    /{id}:
+        uriParameters:
+            id:
+                description: |
+                    The conversation ID.
+                type: string
+
+
+        get:
+            description: |
+                 Get the conversation specified in the id parameter.<br/>
+                 The caller must be one of the requested conversation's participant.<br/>
+                
+  
+            is: []
+
+            queryParameters:
+                includeActivities:
+                    description: |
+                        Specified if activities of conversation will be return as part of the payload.
+                    type: boolean
+
+
+                includeParticipants:
+                    description: |
+                        Specified if list of participant will be return as part of the payload.
+                    type: boolean
+
+
+                activitiesLimit:
+                    description: |
+                        The maximum number of activities returned.
+                    type: integer
+
+
+                sinceDate:
+                    description: |
+                        Activities return must be on or after this date. Date string in unix epoch time format.
+                    type: string
+                beforeDate:
+                    description: |
+                        Activities return must be before this date. Date string in unix epoch time format.
+                    type: string
+                ackFilter:
+                    description: |
+                        (experimental, subject to change) Control how read receipt(a.k.a acknowledge) activity to be returned. 3 possible values. "noack": no ack return, "none"(default): no filtering, include everything, "ackonly": only include read receipt activity and nothing else
+                    type: string
+
+
+                uuidEntryFormat:
+                    description: |
+                        Specified if participant object return should contain both uuid and email format. Default is false, meaning only email as id is retured.
+                    type: boolean
+
+
+                personRefresh:
+                    description: |
+                        (experimental)control if the person detail in activity need to be refreshed to latest. If person detail got refreshed, person.id will be in UUID format even if original one is email. Default is false.
+                    type: boolean
+
+
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Conversation","properties":{"clientTempId":{"type":"string"},"convParticipantPropsList":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ConvParticipantProps","properties":{"participantId":{"type":"string"},"seenActivityTime":{"type":"integer"},"seenActivityUUID":{"type":"string"},"participantEmailAddress":{"type":"string"},"participant":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Person"},"isOfflineNotificationDisabled":{"type":"boolean"}}}},"activity":{"type":"boolean"},"displayName":{"type":"string"},"encryptionKeyConvTitleUrl":{"type":"string"},"uuid":{"type":"string"},"content":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"locusUrl":{"type":"string"},"id":{"type":"string"},"event":{"type":"boolean"},"conversation":{"type":"boolean"},"participants":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"image":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink","properties":{"scr":{"type":"string"},"width":{"type":"integer"},"mimeType":{"type":"string"},"url":{"type":"string"},"height":{"type":"integer"}}},"defaultActivityEncryptionKeyUrl":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"url":{"type":"string"},"tags":{"type":"array","items":{"type":"string","enum":["MUTED","HIDDEN","ONE_ON_ONE","FAVORITE"]}},"contentObject":{"type":"boolean"},"activities":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Activity>","properties":{"items":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject","properties":{"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"uuid":{"type":"string"},"url":{"type":"string"},"content":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"contentObject":{"type":"boolean"},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"comment":{"type":"boolean"},"id":{"type":"string"},"locus":{"type":"boolean"},"event":{"type":"boolean"},"conversation":{"type":"boolean"}}},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Place","properties":{"displayName":{"type":"string"},"position":{"type":"string"}}},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}}}},"person":{"type":"boolean"},"mentions":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>","properties":{"items":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Person","properties":{"entryUUID":{"type":"string"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"fullName":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"uuid":{"type":"string"},"url":{"type":"string"},"content":{"type":"string"},"orgId":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"tags":{"type":"array","items":{"type":"string","enum":["CI_NOTFOUND","ENTITLEMENT_NO_SQUARED","SIDE_BOARDED","SIDEBOARD_WITHOUT_INVITE"]}},"contentObject":{"type":"boolean"},"emailAddress":{"type":"string"},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"comment":{"type":"boolean"},"id":{"type":"string"},"locus":{"type":"boolean"},"event":{"type":"boolean"},"email":{"type":"string"},"conversation":{"type":"boolean"}}}}}},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                            example: |
+                                {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","participants": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"activities": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"tags": ["string one of [MUTED,HIDDEN,ONE_ON_ONE,FAVORITE]"],"convParticipantPropsList": [{"isOfflineNotificationDisabled": "boolean","seenActivityUUID": "uuid","participant": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"},"seenActivityTime": "long","participantId": "uuid","participantEmailAddress": {}}],"clientTempId": "string","locusUrl": "url","defaultActivityEncryptionKeyUrl": "url","encryptionKeyConvTitleUrl": "url"}
+
+        /space:
+            uriParameters:
+            put:
+                description: |
+                     Create Space in the file store for the given conversation. <br/>
+                     Content can then be uploaded to the space for storage. <br/>
+                    
+  
+                is: []
+
+                queryParameters:
+
+                responses:
+                    200:
+                        body:
+                            application/json:
+                                schema: |
+                                    {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:FileStoreResponse","properties":{"spaceUrl":{"type":"string"}}}
+                                example: |
+                                    {"spaceUrl": "url"}
+
+            /hidden:
+                uriParameters:
+                put:
+                    description: |
+                         Create Hidden Space in the file store for the given conversation. <br/>
+                         Content can then be uploaded to the space for storage. <br/>
+                         The files in the hidden space can be purged.
+                        
+  
+                    is: []
+
+                    queryParameters:
+
+                    responses:
+                        200:
+                            body:
+                                application/json:
+                                    schema: |
+                                        {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:FileStoreResponse","properties":{"spaceUrl":{"type":"string"}}}
+                                    example: |
+                                        {"spaceUrl": "url"}
+
+
+
+
+
+        /fileevents:
+            uriParameters:
+            post:
+                description: |
+                     Handle file event
+                    
+  
+                is: []
+
+                queryParameters:
+
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:voltron:dto:Event","properties":{"clientIpAddress":{"type":"string"},"contentUrl":{"type":"string"},"affectedUser":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:User"},"affectedFile":{"type":"string"},"fileSize":{"type":"integer"},"initiator":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:User","properties":{"entitlements":{"type":"array","items":{"type":"string","enum":["webExSquared","jabberMessenger","webExSquaredActivating","webExFiles","squaredCallInitiation","squaredFusionUC","squaredTeamMember","squaredSupport","messengerInterop","squaredInviter","lyncInterop","squaredFusionCal","webExMeetings","ciscoUC","squaredOnBehalfOf"]}},"name":{"type":"string"},"description":{"type":"string"},"id":{"type":"string"},"type":{"type":"string","enum":["PERSON","MACHINE"]},"department":{"type":"string"},"photos":{"type":"array","items":{"type":"any"}},"email":{"type":"string"},"ims":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:IMAddress","properties":{"jid":{"type":"string"},"type":{"type":"string","enum":["webexSquaredJid","webexMessengerJid","cucmJid","microsoftSipUri"]},"primary":{"type":"boolean"}}}},"phoneNumbers":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:PhoneNumber","properties":{"type":{"type":"string","enum":["work","mobile","fax"]},"value":{"type":"string"}}}},"orgId":{"type":"string"}}},"contentId":{"type":"string"},"share":{"type":"any"},"eventType":{"type":"string","enum":["FILE_ADD","FILE_DELETE","FILE_RESTORE","FILE_EDIT","FILE_MOVE","FILE_DOWNLOAD","SHARE_INVITE","ACCEPT_INVITE","DECLINE_INVITE","CANCEL_INVITE","REMOVE_USER","LEAVE_SHARE","REJOIN_SHARE"]},"version":{"type":"string"},"timestamp":{"type":"integer"}}}
+                        example: |
+                            {"initiator": {"id": "uuid","email": {},"name": "string","type": "string one of [PERSON,MACHINE]","photos": [{}],"iMS": [{"type": "string one of [webexSquaredJid,webexMessengerJid,cucmJid,microsoftSipUri]","jid": "string","primary": "boolean"}],"phoneNumbers": [{"type": "string one of [work,mobile,fax]","value": "string"}],"orgId": {},"department": "string","entitlements": ["string one of [webExSquared,jabberMessenger,webExSquaredActivating,webExFiles,squaredCallInitiation,squaredFusionUC,squaredTeamMember,squaredSupport,messengerInterop,squaredInviter,lyncInterop,squaredFusionCal,webExMeetings,ciscoUC,squaredOnBehalfOf]"],"description": "string"},"timestamp": "long","eventType": "string one of [FILE_ADD,FILE_DELETE,FILE_RESTORE,FILE_EDIT,FILE_MOVE,FILE_DOWNLOAD,SHARE_INVITE,ACCEPT_INVITE,DECLINE_INVITE,CANCEL_INVITE,REMOVE_USER,LEAVE_SHARE,REJOIN_SHARE]","affectedUser": {"id": "uuid","email": {},"name": "string","type": "string one of [PERSON,MACHINE]","photos": [{}],"iMS": [{"type": "string one of [webexSquaredJid,webexMessengerJid,cucmJid,microsoftSipUri]","jid": "string","primary": "boolean"}],"phoneNumbers": [{"type": "string one of [work,mobile,fax]","value": "string"}],"orgId": {},"department": "string","entitlements": ["string one of [webExSquared,jabberMessenger,webExSquaredActivating,webExFiles,squaredCallInitiation,squaredFusionUC,squaredTeamMember,squaredSupport,messengerInterop,squaredInviter,lyncInterop,squaredFusionCal,webExMeetings,ciscoUC,squaredOnBehalfOf]"],"description": "string"},"affectedFile": {"root": "boolean","mappablePath": "boolean"},"share": {},"version": "string","contentUrl": "url","contentId": "uuid","fileSize": "long","clientIpAddress": "string"}
+
+                responses:
+                    200:
+
+
+
+        /participants:
+            uriParameters:
+            get:
+                description: |
+                     Get the participants for a specified conversation in the id parameter.<br/>
+                     This api can only be accessed by services with proper oauth service token.<br/>
+                    
+  
+                is: []
+
+                queryParameters:
+                    participant:
+                        description: |
+                            Participant'S ID.
+                        type: string
+
+
+
+                responses:
+                    200:
+                        body:
+                            application/json:
+                                schema: |
+                                    {"type":"array"}
+                                example: |
+                                    ["uuid"]
+
+
+
+        /locusEvent:
+            uriParameters:
+            post:
+                description: |
+                     Webhook for receiving Locus events and converting them into activities. <br/>
+                     This api can only be accessed by services with proper oauth service token. <br/>
+                    
+                    
+  
+                is: []
+
+                queryParameters:
+
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:event:Event","properties":{"eventType":{"type":"string","enum":["CONVERSATION_BADGE_COUNT","CONVERSATION_ACTIVITY","LOCUS_CREATED","LOCUS_SUMMARY","LOCUS_CANCELLED","LOCUS_PARTICIPANT_JOINED","LOCUS_PARTICIPANT_LEFT","LOCUS_PARTICIPANT_DECLINED","LOCUS_PARTICIPANT_ALERTED","LOCUS_PARTICIPANT_AUDIO_MUTED","LOCUS_PARTICIPANT_AUDIO_UNMUTED","LOCUS_PARTICIPANT_VIDEO_MUTED","LOCUS_PARTICIPANT_VIDEO_UNMUTED","LOCUS_SELF_CHANGED","LOCUS_FLOOR_GRANTED","LOCUS_FLOOR_RELEASED","ROOM_DEVICE_ENTERED","ROOM_DEVICE_EXITED","ROOM_ROOM_UPDATED","ROOM_ROOM_UNCONFIGURED","ROOM_BRING_ROOM_INTO_CALL","ROOM_DEVICE_BROADCASTING_IBEACON","ROOM_REQUEST_FEEDBACK","ROOM_WHITEBOARD_CHANGED","ROOM_WHITEBOARDS_CHANGED","ROOM_WHITEBOARD_SESSIONS_CHANGED","START_TYPING_EVENT","STOP_TYPING_EVENT","ENTER_CONVERSATION_EVENT","EXIT_CONVERSATION_EVENT","ENCRYPTION_CLIENT_ENCRYPT_KEYS","ENCRYPTION_KMS_ENCRYPT_KEYS","ENCRYPTION_CLIENT_DH_KEYS","ENCRYPTION_KEY_RESCUE","ENCRYPTION_KMS_DH_KEYS","ENCRYPTION_KMS_ACK","ENCRYPTION_KMS_CONVERSATION","ENCRYPTION_KMS","ENCRYPTION_KMS_MESSAGE"]},"priority":{"type":"integer"}}}
+                        example: |
+                            {"eventType": "string one of [CONVERSATION_BADGE_COUNT,CONVERSATION_ACTIVITY,LOCUS_CREATED,LOCUS_SUMMARY,LOCUS_CANCELLED,LOCUS_PARTICIPANT_JOINED,LOCUS_PARTICIPANT_LEFT,LOCUS_PARTICIPANT_DECLINED,LOCUS_PARTICIPANT_ALERTED,LOCUS_PARTICIPANT_AUDIO_MUTED,LOCUS_PARTICIPANT_AUDIO_UNMUTED,LOCUS_PARTICIPANT_VIDEO_MUTED,LOCUS_PARTICIPANT_VIDEO_UNMUTED,LOCUS_SELF_CHANGED,LOCUS_FLOOR_GRANTED,LOCUS_FLOOR_RELEASED,ROOM_DEVICE_ENTERED,ROOM_DEVICE_EXITED,ROOM_ROOM_UPDATED,ROOM_ROOM_UNCONFIGURED,ROOM_BRING_ROOM_INTO_CALL,ROOM_DEVICE_BROADCASTING_IBEACON,ROOM_REQUEST_FEEDBACK,ROOM_WHITEBOARD_CHANGED,ROOM_WHITEBOARDS_CHANGED,ROOM_WHITEBOARD_SESSIONS_CHANGED,START_TYPING_EVENT,STOP_TYPING_EVENT,ENTER_CONVERSATION_EVENT,EXIT_CONVERSATION_EVENT,ENCRYPTION_CLIENT_ENCRYPT_KEYS,ENCRYPTION_KMS_ENCRYPT_KEYS,ENCRYPTION_CLIENT_DH_KEYS,ENCRYPTION_KEY_RESCUE,ENCRYPTION_KMS_DH_KEYS,ENCRYPTION_KMS_ACK,ENCRYPTION_KMS_CONVERSATION,ENCRYPTION_KMS,ENCRYPTION_KMS_MESSAGE]","priority": "integer"}
+
+                responses:
+                    200:
+                        body:
+                            application/json:
+                                schema: |
+                                    {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Place"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                                example: |
+                                    {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","verb": "string one of [post,create,add,acknowledge,update,join,mute,unmute,hide,unhide,leave,share,unshare,cancel,reject,schedule,start,terminate,favorite,unfavorite,updateKey,delete,tombstone]","reason": "string","actor": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"object": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"target": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"location": {"displayName": "string","position": "string"},"clientTempId": "string","encryptionKeyUrl": "url","serviceUserId": "string","machineUserId": "string","conversationId": "uuid","addParticipant": "boolean","createConversation": "boolean","postOrAddComment": "boolean","postOrAddFile": "boolean","postOrAdd": "boolean","acknowledgeActivity": "boolean","updateTitleActivity": "boolean","postLocusCreatedActivity": "boolean","muteConversation": "boolean","unMuteConversation": "boolean","favoriteConversation": "boolean","unFavoriteConversation": "boolean","updateKey": "boolean","hideActivity": "boolean","unHideConversation": "boolean","leaveConversation": "boolean","startLocus": "boolean","cancelLocus": "boolean","rejectLocus": "boolean","terminateLocus": "boolean","joinLocus": "boolean","leaveLocus": "boolean","locusSessionSummary": "boolean","shareContent": "boolean","shareImages": "boolean","shareVideos": "boolean","shareDocuments": "boolean","scheduleEvent": "boolean","contentCategory": "string one of [images,videos,tasks,documents]"}
+
+
+
+        /locus:
+            uriParameters:
+            put:
+                description: |
+                     Temporary endpoint to do soft migration for permanent locus
+                     This endpoint should be removed after the actual data migration for Perm Locus takes place.<br/>
+                    
+  
+                is: []
+
+                queryParameters:
+
+                responses:
+                    200:
+                        body:
+                            application/json:
+                                schema: |
+                                    {"type":"any"}
+                                example: |
+                                    {}
+
+            get:
+                description: |
+                     Endpoint to return a locus redirect for GET requests
+                    
+  
+                is: []
+
+                queryParameters:
+                    status:
+                        description: |
+                            
+                        type: integer
+
+
+
+                responses:
+                    200:
+
+            delete:
+                description: |
+                     Endpoint for test users to delete perm locus
+                    
+  
+                is: []
+
+                queryParameters:
+
+                responses:
+                    200:
+
+            /**:
+                uriParameters:
+                post:
+                    description: |
+                         Endpoint to do redirects for locus urls.<br/>
+                         This will be used by existing conversations which doesnt have
+                         a locus url. locusRequestObject is just a catch all object for
+                         all types of json client sends with locus requests.<br/>
+                        
+  
+                    is: []
+
+                    queryParameters:
+
+                    responses:
+                        200:
+
+
+
+
+
+
+
+    /left:
+        uriParameters:
+        get:
+            description: |
+                 Return a list of conversation that user left in the past.<br/>
+                 The list of the conversation is bounded by the sinceDate and maxDate. <br/>
+                 The conversation object return is a *skinny* version which only contains the conversation id,
+                 other information like participants or activities etc are not included as part of return payload.
+                
+  
+            is: []
+
+            queryParameters:
+                sinceDate:
+                    description: |
+                        User left the conversation after this date. Date string in unix epoch time format.
+                    type: string
+                maxDate:
+                    description: |
+                        User left the conversation before this date. Date string in unix epoch time format.
+                    type: string
+                conversationsLimit:
+                    description: |
+                        Maximum number of conversation return in this call. Default is 1000.
+                    type: integer
+
+
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"}}}}
+                            example: |
+                                {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}
+
+
+
+    /unread:
+        uriParameters:
+        get:
+            description: |
+                 Return a list of conversation that is unread to user.<br/>
+                 The conversation object return is a *skinny* version which only contains the conversation id,
+                 other information like participants or activities etc are not included as part of return payload.
+                
+  
+            is: []
+
+            queryParameters:
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"}}}}
+                            example: |
+                                {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}
+
+
+
+    /relevant:
+        uriParameters:
+        get:
+            description: |
+                 Return a list of relevant conversations.
+                
+  
+            is: []
+
+            queryParameters:
+                sinceDate:
+                    description: |
+                        Last activity time of the conversation is after this date. Date string in unix epoch time format.
+                    type: string
+                maxDate:
+                    description: |
+                        Last activity time of the conversation is before this date. Date string in unix epoch time format.
+                    type: string
+                ackFilter:
+                    description: |
+                        Control how read receipt(a.k.a acknowledge) activity to be returned. 3 possible values. "noack": no ack return, "all"(default): no filtering, include everything, "myack": only include read receipt from caller of this api
+                    type: string
+
+
+                participantsLimit:
+                    description: |
+                        The maximum number of participants return inside conversation participant listing.
+                    type: integer
+
+
+                conversationsLimit:
+                    description: |
+                        Maximum number of conversation return. Default is 50.
+                    type: integer
+
+
+                activitiesLimit:
+                    description: |
+                        Maximum number of activities(non-acknowledge type) return within each conversation. Default is 50.
+                    type: integer
+
+
+                lastViewableActivityOnly:
+                    description: |
+                        If set to true, only return last viewable activity within a conversation returned, activitiesLimit parameter is ignored. Default is false;
+                    type: boolean
+
+
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"}}}}
+                            example: |
+                                {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}
+
+
+
+    /user/{participant}:
+        uriParameters:
+            participant:
+                description: |
+                    String id in the form of uuid or email address. This is required field.
+                type: string
+        put:
+            description: |
+                 Returns the 1:1 conversation between the two participants. <br/>
+                 The 1:1 conversation will be created by the server if it does not already exist.<br/>
+                 The authenticated user is automatically selected as one of participant,
+                 and the other participant must be specified in the "participant" parameter.<br/>
+                 Both user need to be in Common Identity, so that the target UUID can be extracted through CI since 1:1 conversations are mapped through the
+                 user UUID's. <br/>
+                 <hr/>
+                
+  
+            is: []
+
+            queryParameters:
+                participantDisplayName:
+                    description: |
+                        Display name of the participant. To be used only when trying to side-board the participant.
+                    type: string
+
+
+                serverSideInvite:
+                    description: |
+                        If true, invitation to join project squared will be sent by the atlas service else not. Default is true.
+                    type: boolean
+
+
+                activitiesLimit:
+                    description: |
+                        Number of activities want to be included in the conversation returned. Default is 6.
+                    type: integer
+
+
+                compact:
+                    description: |
+                        If true, conversation created will not include the initial add participant activities. <br/>This is helpful when creating a big conversation with lot of initial participants. Default is false.
+                    type: boolean
+
+
+                encryptionKey:
+                    description: |
+                        
+                    type: string
+
+
+                creationDate:
+                    description: |
+                        
+                    type: date
+
+
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Conversation","properties":{"clientTempId":{"type":"string"},"convParticipantPropsList":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ConvParticipantProps"}},"activity":{"type":"boolean"},"displayName":{"type":"string"},"encryptionKeyConvTitleUrl":{"type":"string"},"uuid":{"type":"string"},"content":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"locusUrl":{"type":"string"},"id":{"type":"string"},"event":{"type":"boolean"},"conversation":{"type":"boolean"},"participants":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"defaultActivityEncryptionKeyUrl":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"url":{"type":"string"},"tags":{"type":"array","items":{"type":"string","enum":["MUTED","HIDDEN","ONE_ON_ONE","FAVORITE"]}},"contentObject":{"type":"boolean"},"activities":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Activity>"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                            example: |
+                                {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","participants": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"activities": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"tags": ["string one of [MUTED,HIDDEN,ONE_ON_ONE,FAVORITE]"],"convParticipantPropsList": [{"isOfflineNotificationDisabled": "boolean","seenActivityUUID": "uuid","participant": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"},"seenActivityTime": "long","participantId": "uuid","participantEmailAddress": {}}],"clientTempId": "string","locusUrl": "url","defaultActivityEncryptionKeyUrl": "url","encryptionKeyConvTitleUrl": "url"}
+
+
+
+    /digests/users/{userId}/status:
+        uriParameters:
+            userId:
+                description: |
+                    
+                type: string
+        get:
+  
+            is: []
+
+            queryParameters:
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"any"}
+                            example: |
+                                {}
+
+
+
+
+/conversation/api/v1/synconversations:
+    uriParameters:
+    get:
+        description: |
+             Getting a list of caller's conversation that meet the criteria specified in the parameters.
+            
+             This is a improved version of our original getConversations API. <br/>
+             This API is currently in experimental stage, and it is subject to change with no backward compatibility promise.
+            
+             The intention of this API is for client to quickly load up all the conversations that can be displayed as
+             conversation list view.
+            
+             A different API should be used(getActivities) to catch up or synch the rest of the activities within a conversation
+            
+             The conversations return is stored by descending order of the last activity of the conversation.
+             The activities is sorted by descending order, so last activity will come first. <br/>
+             The participant return in the conversation is sorted by the descending order of user's last activity to the conversation. (To be implemented)
+            
+            
+  
+        is: []
+
+        queryParameters:
+            sinceDate:
+                description: |
+                    Last activity time of the conversation is after this date. Date string in unix epoch time format.
+                type: string
+            maxDate:
+                description: |
+                    Last activity time of the conversation is before this date. Date string in unix epoch time format.
+                type: string
+            ackFilter:
+                description: |
+                    (TBD) Control how read receipt(a.k.a acknowledge) activity to be returned. 3 possible values. "noack": no ack return, "all"(default): no filtering, include everything, "myack": only include read receipt from caller of this api
+                type: string
+
+
+            participantsLimit:
+                description: |
+                    (TBD) The maximum number of participants return inside conversation participant listing.
+                type: integer
+
+
+            activitiesLimit:
+                description: |
+                    The Maximum number of activities return. Default is 1. Returning just one actvity(last one) has much better performance when requesting more than 1.
+                type: integer
+
+
+            conversationsLimit:
+                description: |
+                    Maximum number of conversation return. Default is 1000.
+                type: integer
+
+
+            isActive:
+                description: |
+                    
+                type: boolean
+
+
+            isFavorite:
+                description: |
+                    
+                type: boolean
+
+
+            uuidEntryFormat:
+                description: |
+                    Specified if participant object return should contain both uuid and email format. Default is false, meaning only email as id is retured.
+                type: boolean
+
+
+            lastViewableActivityOnly:
+                description: |
+                    If set to true, only return last viewable activity within a conversation returned, activitiesLimit parameter is ignored. Default is false;
+                type: boolean
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"}}}}
+                        example: |
+                            {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}
+
+
+/conversation/api/v1/contents/{id}:
+    uriParameters:
+        id:
+            description: |
+                activity uuid in string format
+            type: string
+
+
+    get:
+        description: |
+             Get an activity object back with the given activity id.<br/>
+             The caller must be part of the conversation's participant list that the requested activity
+             belongs to.<br/>
+             
+  
+        is: []
+
+        queryParameters:
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ContentObject","properties":{"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"published":{"type":"integer","format":"UTC_MILLISEC"},"uuid":{"type":"string"},"url":{"type":"string"},"content":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"contentCategory":{"type":"string","enum":["images","videos","tasks","documents"]},"contentObject":{"type":"boolean"},"file":{"type":"boolean"},"locusSessionSummary":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"files":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:FileObject>"},"comment":{"type":"boolean"},"id":{"type":"string"},"locus":{"type":"boolean"},"event":{"type":"boolean"},"conversation":{"type":"boolean"}}}
+                        example: |
+                            {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","files": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"contentCategory": "string one of [images,videos,tasks,documents]"}
+
+
+/conversation/api/v1/activities:
+    uriParameters:
+    get:
+        description: |
+             Return a list of activities within a given conversation and other constraints.
+            
+  
+        is: []
+
+        queryParameters:
+            conversationId:
+                description: |
+                    Conversation id in string format
+                type: string
+
+
+            sinceDate:
+                description: |
+                    the activities published date is after this date
+                type: string
+            maxDate:
+                description: |
+                    the activities published date is before this date
+                type: string
+            limit:
+                description: |
+                    Maximum number of activities return. Default is 6.
+                type: integer
+
+
+            personRefresh:
+                description: |
+                    (experimental)control if the person detail in activity need to be refreshed to latest. If person detail got refreshed, person.id will be in UUID format even if original one is email. Default is false.
+                type: boolean
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection","properties":{"items":{"type":"array","items":{"$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"}}}}
+                        example: |
+                            {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]}
+
+    post:
+        description: |
+             Main API to add event or activity to conversation.<br/>
+             Detail of the activity is entirely encapsulated inside the activity object that submitted from caller.<br/>
+             The activity object return by this call is exact the same requested by caller with id and published field now filled in by server. <br/>
+             The conversation server supports a subset of the activities defined in <a target="_blank" href="http://activitystrea.ms">Activity Streams 1.0</a>. <br/>
+             In summary, each activity has an "actor" (usually a person), a "verb", an activity "object", and an optional activity "target". <br/>
+             <br/>
+             Currently, the following verbs are supported, see examples section for details.
+             <p/>
+             <ul>
+             <li><b>add</b> : adding participant to conversation
+             <li><b>leave</b> : leave a conversation
+             <li><b>post</b> : send a text message to conversation
+             <li><b>acknowledge</b>: acknowledge an activity
+             <li><b>update</b>: update a conversation title
+             <li><b>hide</b> : hide a conversation
+             <li><b>unhide</b> : unhide a conversation
+             <li><b>mute</b> : mute a conversation
+             <li><b>unmute</b> : unmute a conversation
+             <li><b>favorite</b> : favorite a conversation
+             <li><b>unfavorite</b> : unfavorite a conversation
+             <li><b>share</b> : share a content with participant in a conversation
+             <li><b>delete</b> : delete an activity item (the target of this activity)
+             </ul>
+            
+  
+        is: []
+
+        queryParameters:
+
+        body:
+            application/json:
+                schema: |
+                    {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Place"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                example: |
+                    {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","verb": "string one of [post,create,add,acknowledge,update,join,mute,unmute,hide,unhide,leave,share,unshare,cancel,reject,schedule,start,terminate,favorite,unfavorite,updateKey,delete,tombstone]","reason": "string","actor": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"object": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"target": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"location": {"displayName": "string","position": "string"},"clientTempId": "string","encryptionKeyUrl": "url","serviceUserId": "string","machineUserId": "string","conversationId": "uuid","addParticipant": "boolean","createConversation": "boolean","postOrAddComment": "boolean","postOrAddFile": "boolean","postOrAdd": "boolean","acknowledgeActivity": "boolean","updateTitleActivity": "boolean","postLocusCreatedActivity": "boolean","muteConversation": "boolean","unMuteConversation": "boolean","favoriteConversation": "boolean","unFavoriteConversation": "boolean","updateKey": "boolean","hideActivity": "boolean","unHideConversation": "boolean","leaveConversation": "boolean","startLocus": "boolean","cancelLocus": "boolean","rejectLocus": "boolean","terminateLocus": "boolean","joinLocus": "boolean","leaveLocus": "boolean","locusSessionSummary": "boolean","shareContent": "boolean","shareImages": "boolean","shareVideos": "boolean","shareDocuments": "boolean","scheduleEvent": "boolean","contentCategory": "string one of [images,videos,tasks,documents]"}
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Place"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                        example: |
+                            {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","verb": "string one of [post,create,add,acknowledge,update,join,mute,unmute,hide,unhide,leave,share,unshare,cancel,reject,schedule,start,terminate,favorite,unfavorite,updateKey,delete,tombstone]","reason": "string","actor": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"object": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"target": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"location": {"displayName": "string","position": "string"},"clientTempId": "string","encryptionKeyUrl": "url","serviceUserId": "string","machineUserId": "string","conversationId": "uuid","addParticipant": "boolean","createConversation": "boolean","postOrAddComment": "boolean","postOrAddFile": "boolean","postOrAdd": "boolean","acknowledgeActivity": "boolean","updateTitleActivity": "boolean","postLocusCreatedActivity": "boolean","muteConversation": "boolean","unMuteConversation": "boolean","favoriteConversation": "boolean","unFavoriteConversation": "boolean","updateKey": "boolean","hideActivity": "boolean","unHideConversation": "boolean","leaveConversation": "boolean","startLocus": "boolean","cancelLocus": "boolean","rejectLocus": "boolean","terminateLocus": "boolean","joinLocus": "boolean","leaveLocus": "boolean","locusSessionSummary": "boolean","shareContent": "boolean","shareImages": "boolean","shareVideos": "boolean","shareDocuments": "boolean","scheduleEvent": "boolean","contentCategory": "string one of [images,videos,tasks,documents]"}
+
+    /{id}:
+        uriParameters:
+            id:
+                description: |
+                    activity uuid in string format
+                type: string
+
+
+        get:
+            description: |
+                 Get an activity object back with the given activity id.<br/>
+                 The caller must be part of the conversation's participant list that the requested activity belongs to.<br/>
+                
+  
+            is: []
+
+            queryParameters:
+                personRefresh:
+                    description: |
+                        (experimental)control if the person detail in activity need to be refreshed to latest. If person detail got refreshed, person.id will be in UUID format even if original one is email. Default is false.
+                    type: boolean
+
+
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Place"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                            example: |
+                                {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","verb": "string one of [post,create,add,acknowledge,update,join,mute,unmute,hide,unhide,leave,share,unshare,cancel,reject,schedule,start,terminate,favorite,unfavorite,updateKey,delete,tombstone]","reason": "string","actor": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"object": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"target": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"location": {"displayName": "string","position": "string"},"clientTempId": "string","encryptionKeyUrl": "url","serviceUserId": "string","machineUserId": "string","conversationId": "uuid","addParticipant": "boolean","createConversation": "boolean","postOrAddComment": "boolean","postOrAddFile": "boolean","postOrAdd": "boolean","acknowledgeActivity": "boolean","updateTitleActivity": "boolean","postLocusCreatedActivity": "boolean","muteConversation": "boolean","unMuteConversation": "boolean","favoriteConversation": "boolean","unFavoriteConversation": "boolean","updateKey": "boolean","hideActivity": "boolean","unHideConversation": "boolean","leaveConversation": "boolean","startLocus": "boolean","cancelLocus": "boolean","rejectLocus": "boolean","terminateLocus": "boolean","joinLocus": "boolean","leaveLocus": "boolean","locusSessionSummary": "boolean","shareContent": "boolean","shareImages": "boolean","shareVideos": "boolean","shareDocuments": "boolean","scheduleEvent": "boolean","contentCategory": "string one of [images,videos,tasks,documents]"}
+
+
+
+
+/conversation/api/v1/content:
+    uriParameters:
+    post:
+        description: |
+             This API can be used to share content asynchronously to the conversation. <br/>
+             <br/>
+             This API goes through the following logic ... <br/>
+             Step 1: Validates that it is a valid "share content" activity. <br/>
+             Step 2: If the content category is of not of the type "documents", <br/>
+             then persists the activity without looking for transcoded data.<br/>
+             Step 3: If the content category is of type "documents", checks if <br/>
+             there are any transcodable files being shared.<br/>
+             Step 4: If no transcodable files are being shared, then persists the activity <br/>
+             right away.<br/>
+             Step 5: If transcodable files exists, checks and waits for transcode <br/>
+             data to be available.<br/>
+             Step 6: If transcoded data is available, it associates the transcoded <br/>
+             content and persists activity.<br/>
+             Step 7: If transcoded data is not available even after 3 minutes wait, it <br/>
+             persists the activity without any transcode data.<br/>
+             
+             Only the following verb is supported.
+             <p/>
+             <ul>
+             <li><b>share</b> : share a content with participants in a conversation
+             </ul>
+             
+  
+        is: []
+
+        queryParameters:
+            async:
+                description: |
+                    If false, the content share activity will be added synchronously without waiting for transcode to finish.
+                type: boolean
+
+
+            transcode:
+                description: |
+                    
+                type: boolean
+
+
+
+        body:
+            application/json:
+                schema: |
+                    {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Place"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                example: |
+                    {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","verb": "string one of [post,create,add,acknowledge,update,join,mute,unmute,hide,unhide,leave,share,unshare,cancel,reject,schedule,start,terminate,favorite,unfavorite,updateKey,delete,tombstone]","reason": "string","actor": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"object": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"target": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"location": {"displayName": "string","position": "string"},"clientTempId": "string","encryptionKeyUrl": "url","serviceUserId": "string","machineUserId": "string","conversationId": "uuid","addParticipant": "boolean","createConversation": "boolean","postOrAddComment": "boolean","postOrAddFile": "boolean","postOrAdd": "boolean","acknowledgeActivity": "boolean","updateTitleActivity": "boolean","postLocusCreatedActivity": "boolean","muteConversation": "boolean","unMuteConversation": "boolean","favoriteConversation": "boolean","unFavoriteConversation": "boolean","updateKey": "boolean","hideActivity": "boolean","unHideConversation": "boolean","leaveConversation": "boolean","startLocus": "boolean","cancelLocus": "boolean","rejectLocus": "boolean","terminateLocus": "boolean","joinLocus": "boolean","leaveLocus": "boolean","locusSessionSummary": "boolean","shareContent": "boolean","shareImages": "boolean","shareVideos": "boolean","shareDocuments": "boolean","scheduleEvent": "boolean","contentCategory": "string one of [images,videos,tasks,documents]"}
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:activity:Activity","properties":{"reason":{"type":"string"},"postOrAdd":{"type":"boolean"},"updateKey":{"type":"boolean"},"acknowledgeActivity":{"type":"boolean"},"uuid":{"type":"string"},"objectType":{"type":"string","enum":["person","conversation","comment","file","activity","locus","locusSessionSummary","locusSessionSummaryParticipant","room","content","transcodedContent","venue","event"]},"locusSessionSummary":{"type":"boolean"},"addParticipant":{"type":"boolean"},"id":{"type":"string"},"unMuteConversation":{"type":"boolean"},"conversation":{"type":"boolean"},"image":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:MediaLink"},"rejectLocus":{"type":"boolean"},"postLocusCreatedActivity":{"type":"boolean"},"verb":{"type":"string","enum":["post","create","add","acknowledge","update","join","mute","unmute","hide","unhide","leave","share","unshare","cancel","reject","schedule","start","terminate","favorite","unfavorite","updateKey","delete","tombstone"]},"joinLocus":{"type":"boolean"},"published":{"type":"integer","format":"UTC_MILLISEC"},"contentObject":{"type":"boolean"},"startLocus":{"type":"boolean"},"shareDocuments":{"type":"boolean"},"person":{"type":"boolean"},"mentions":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityCollection<com:cisco:wx2:dto:activity:Person>"},"object":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"hideActivity":{"type":"boolean"},"cancelLocus":{"type":"boolean"},"clientTempId":{"type":"string"},"muteConversation":{"type":"boolean"},"favoriteConversation":{"type":"boolean"},"shareVideos":{"type":"boolean"},"activity":{"type":"boolean"},"displayName":{"type":"string"},"createConversation":{"type":"boolean"},"content":{"type":"string"},"leaveLocus":{"type":"boolean"},"encryptionKeyUrl":{"type":"string"},"scheduleEvent":{"type":"boolean"},"postOrAddComment":{"type":"boolean"},"shareContent":{"type":"boolean"},"file":{"type":"boolean"},"event":{"type":"boolean"},"unFavoriteConversation":{"type":"boolean"},"updateTitleActivity":{"type":"boolean"},"conversationId":{"type":"string"},"postOrAddFile":{"type":"boolean"},"terminateLocus":{"type":"boolean"},"shareImages":{"type":"boolean"},"url":{"type":"string"},"target":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"actor":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:ActivityObject"},"unHideConversation":{"type":"boolean"},"serviceUserId":{"type":"string"},"machineUserId":{"type":"string"},"leaveConversation":{"type":"boolean"},"location":{"type":"object","$ref":"urn:jsonschema:com:cisco:wx2:dto:activity:Place"},"comment":{"type":"boolean"},"locus":{"type":"boolean"}}}
+                        example: |
+                            {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","verb": "string one of [post,create,add,acknowledge,update,join,mute,unmute,hide,unhide,leave,share,unshare,cancel,reject,schedule,start,terminate,favorite,unfavorite,updateKey,delete,tombstone]","reason": "string","actor": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"object": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"target": {"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": {"items": [{"id": "string","uuid": "uuid","objectType": "string one of [person,conversation,comment,file,activity,locus,locusSessionSummary,locusSessionSummaryParticipant,room,content,transcodedContent,venue,event]","url": "url","published": "timestamp","content": "string","displayName": "string","image": {"url": "url","height": "integer","width": "integer","mimeType": "string","scr": "string"},"mentions": "ActivityCollection recursive","person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean","email": {},"entryUUID": "uuid","fullName": "string","tags": ["string one of [CI_NOTFOUND,ENTITLEMENT_NO_SQUARED,SIDE_BOARDED,SIDEBOARD_WITHOUT_INVITE]"],"orgId": "string","emailAddress": "string"}]},"person": "boolean","conversation": "boolean","activity": "boolean","comment": "boolean","contentObject": "boolean","file": "boolean","event": "boolean","locus": "boolean","locusSessionSummary": "boolean"},"location": {"displayName": "string","position": "string"},"clientTempId": "string","encryptionKeyUrl": "url","serviceUserId": "string","machineUserId": "string","conversationId": "uuid","addParticipant": "boolean","createConversation": "boolean","postOrAddComment": "boolean","postOrAddFile": "boolean","postOrAdd": "boolean","acknowledgeActivity": "boolean","updateTitleActivity": "boolean","postLocusCreatedActivity": "boolean","muteConversation": "boolean","unMuteConversation": "boolean","favoriteConversation": "boolean","unFavoriteConversation": "boolean","updateKey": "boolean","hideActivity": "boolean","unHideConversation": "boolean","leaveConversation": "boolean","startLocus": "boolean","cancelLocus": "boolean","rejectLocus": "boolean","terminateLocus": "boolean","joinLocus": "boolean","leaveLocus": "boolean","locusSessionSummary": "boolean","shareContent": "boolean","shareImages": "boolean","shareVideos": "boolean","shareDocuments": "boolean","scheduleEvent": "boolean","contentCategory": "string one of [images,videos,tasks,documents]"}
+
+
+/conversation/api/v1/logToken:
+    uriParameters:
+    get:
+        description: |
+             An endpoint to return a dynamic logging token based on the client identifier.<br/>
+             This token is valid for 30 minutes.<br/>
+             the client should start setting this token in their request headers to
+             dynamically set the log level to debug.<br/>
+             The client identifier should only be 4 characters long.
+            
+  
+        is: []
+
+        queryParameters:
+            clientIdentifier:
+                description: |
+                    
+                type: string
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"any"}
+                        example: |
+                            {}
+
+
+/conversation/api/v1/reports:
+    uriParameters:
+    post:
+        description: |
+             Rest endpoint to gather reports per day for an org. <br/>
+            
+            
+  
+        is: []
+
+        queryParameters:
+
+        body:
+            application/json:
+                schema: |
+                    {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:storage:Reports","properties":{"reportType":{"type":"string","enum":["File_Storage_Usage","Message_Usage"]},"includeUserStat":{"type":"boolean"},"orgs":{"type":"array","items":{"type":"string"}}}}
+                example: |
+                    {"reportType": "string one of [File_Storage_Usage,Message_Usage]","includeUserStat": "boolean","orgs": [{}]}
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:storage:OrgStorageDetailsCollection","properties":{"orgStorageDetailsCollection":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:storage:OrgStorageDetails","properties":{"totalOrgMegaBytes":{"type":"integer"},"orgId":{"type":"string"},"userStorageDetailsList":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:storage:UserStorageDetails","properties":{"totalOrgMegaBytes":{"type":"integer"},"totalUserMegaBytes":{"type":"integer"},"userId":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:util:UserId","properties":{"uuid":{"type":"boolean"},"email":{"type":"boolean"}}},"orgId":{"type":"string"}}}}}}}}}
+                        example: |
+                            {"orgStorageDetailsCollection": [{"totalOrgMegaBytes": "float","orgId": {},"userStorageDetailsList": [{"totalOrgMegaBytes": "float","orgId": {},"userId": {"uuid": "boolean","email": "boolean"},"totalUserMegaBytes": "float"}]}]}
+
+
+/conversation/api/v1/e2econversations/healed:
+    uriParameters:
+    get:
+        description: |
+             Temp endpoint to help client fix conversation encryption key not associate with kms issue.
+             Rely on KMSClient to backdoor request the authorization with a resource in KMSServer.
+             This is consisder tmp solution and will subject to change in near future.
+            
+  
+        is: []
+
+        queryParameters:
+            conversationId:
+                description: |
+                    
+                type: string
+
+
+            resetKey:
+                description: |
+                    
+                type: boolean
+
+
+
+        responses:
+            200:
+                body:
+                    application/json:
+                        schema: |
+                            {"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:encryption:MultiEncryptionKeyRescueInfo","properties":{"rescueInfoList":{"type":"array","items":{"type":"object","id":"urn:jsonschema:com:cisco:wx2:dto:encryption:EncryptionKeyRescueInfo","properties":{"resource":{"type":"string"},"failureReason":{"type":"string"},"keyUrl":{"type":"string"},"statusCode":{"type":"integer"},"participants":{"type":"array","items":{"type":"string"}}}}}}}
+                        example: |
+                            {"rescueInfoList": [{"resource": "url","keyUrl": "url","statusCode": "integer","failureReason": "string","participants": ["uuid"]}]}
+
+
+
+


### PR DESCRIPTION
Note, I didn't add pretty-printing for other mediatypes, but the prettyPrint() helper could be pretty easily extended to do that.  Also, I didn't do anything with the default item.handlebars, though it apparently contains a schema and example template as well.