### PR TITLE
Added background color for PATCH badge to CSS.

### DIFF
--- a/lib/template.handlebars
+++ b/lib/template.handlebars
@@ -61,6 +61,9 @@
         .badge_delete {
             background-color: #d26460;
         }
+        .badge_patch {
+            background-color: #ccc444;
+        }
         .list-group, .panel-group {
             margin-bottom: 0;
         }


### PR DESCRIPTION
I dislike the default gray, so I added a nice yellow background. From what I've seen online, PATCH is becoming more popular, so it should be supported.