### PR TITLE
Response tab is set to active when request tab isn't shown

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -16,6 +16,10 @@ renderer.table = function(thead, tbody) {
     return '<table class="table"><thead>' + thead + '</thead><tbody>' + tbody + '</tbody></table>';
 };
 
+function responseExists(context) {
+    return (context.allUriParameters.length || context.queryParameters || context.headers || context.body);
+}
+
 function _markDownHelper(text) {
     if (text && text.length) {
         return new handlebars.SafeString(marked(text, { renderer: renderer }));
@@ -46,8 +50,14 @@ function _emptyResourceCheckHelper(options) {
 }
 
 function _emptyRequestCheckHelper(options) {
-    if (this.allUriParameters.length || this.queryParameters || this.headers || this.body) {
-        return options.fn(this);
+    if (responseExists(this)) {
+        return options.fn(this)
+    }
+}
+
+function _missingRequestCheckHelper(options) {
+    if (!responseExists(this)) {
+        return options.fn(this)
     }
 }
 
@@ -121,6 +131,7 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
         helpers: {
             emptyResourceCheck: _emptyResourceCheckHelper,
             emptyRequestCheckHelper: _emptyRequestCheckHelper,
+            missingRequestCheckHelper: _missingRequestCheckHelper,
             md: _markDownHelper,
             lock: _lockIconHelper,
             ifTypeIsString: _ifTypeIsString

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -66,7 +66,7 @@
                                 {{/emptyRequestCheckHelper}}
 
                                 {{#if responses}}
-                                    <li>
+                                    <li{{#missingRequestCheckHelper}} class="active"{{/missingRequestCheckHelper}}>
                                         <a href="#{{../../uniqueId}}_{{method}}_response" data-toggle="tab">Response</a>
                                     </li>
                                 {{/if}}
@@ -131,7 +131,7 @@
                                 {{/emptyRequestCheckHelper}}
 
                                 {{#if responses}}
-                                    <div class="tab-pane" id="{{../../uniqueId}}_{{method}}_response">
+                                    <div class="tab-pane{{#missingRequestCheckHelper}} active{{/missingRequestCheckHelper}}" id="{{../../uniqueId}}_{{method}}_response">
                                         {{#each responses}}
                                             <h2>HTTP status code <a href="http://httpstatus.es/{{@key}}" target="_blank">{{@key}}</a></h2>
                                             {{md this.description}}


### PR DESCRIPTION
If no request content is present when viewing a given method's details, the modal would load without a selected tab and fail to render the 'Response' tab button. This PR sets the response tab to active in that case.

I've added a handlebars helper called 'missingRequestCheckHelper' that renders content (in this case, adding the active class) if request details are missing. The naming is a little confusing, since we already have an 'emptyRequestCheckHelper' (which does the opposite - renders if method has request details). Let me know if you have a better approach!
