### PR TITLE
add support for pretty-print of JSON schema and examples (issue #111)

### DIFF
--- a/examples/checkers.raml
+++ b/examples/checkers.raml
@@ -1,0 +1,35 @@
+#%RAML 0.8
+---
+title: Checkers
+version: v1
+baseUri: /api/v1
+documentation:
+    - title: Overview
+      content: |
+           Draughts (/ˈdrɑːfts/, British English) or checkers (American English) is a group of strategy board games for 
+           two players which involve diagonal moves of uniform game pieces and mandatory captures by jumping over opponent 
+           pieces. Draughts developed from alquerque. The name derives from the verb to draw or to move.
+          
+/api/v1:
+    uriParameters:
+    /checkers/games:
+        uriParameters:
+        get:
+            description: |
+                 Retrieves a collection of existing games from the server.
+                
+            queryParameters:
+                state:
+                    description:  Filters the selection on state.
+                    type: string
+                    enum: [ STARTING, ACTIVE, PAUSED, ENDED ]
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:org:madpolicy:dto:GameCollection","properties":{"games":{"type":"array","items":{"type":"object","id":"urn:jsonschema:org:madpolicy:dto:Game","properties":{"gameboard":{"type":"array","required":true,"description":"The state of the gameboard.","items":{"type":"array","items":{"type":"string","enum":["ToString:RED","ToString:BLACK","ToString:FREE"]}}},"name":{"type":"string","description":"Name of the game."}}}}}}
+                            example: |
+                                {"games": [{"name": "string","gameboard": "string one of [RED,BLACK,FREE]"}]}
+

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -69,6 +69,13 @@ function _ifTypeIsString(options) {
     }
 }
 
+function _prettyPrint(type, schema) {
+    if (type === "application/json") {
+        return JSON.stringify(JSON.parse(schema), null, " ");
+    }
+    return schema;
+}
+
 /*
  The config object can contain the following keys and values:
  template: string or Handlebars object containing the main template (required)
@@ -134,7 +141,8 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
             missingRequestCheckHelper: _missingRequestCheckHelper,
             md: _markDownHelper,
             lock: _lockIconHelper,
-            ifTypeIsString: _ifTypeIsString
+            ifTypeIsString: _ifTypeIsString,
+            prettyPrint: _prettyPrint
         },
         partials: {
             resource: resourceTemplate,

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -118,12 +118,12 @@
 
                                                 {{#if this.schema}}
                                                     <p><strong>Schema</strong>:</p>
-                                                    <pre><code>{{this.schema}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                 {{/if}}
 
                                                 {{#if this.example}}
                                                     <p><strong>Example</strong>:</p>
-                                                    <pre><code>{{this.example}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                 {{/if}}
                                             {{/each}}
                                         {{/if}}
@@ -152,12 +152,12 @@
 
                                                     {{#if this.schema}}
                                                         <p><strong>Schema</strong>:</p>
-                                                        <pre><code>{{this.schema}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                     {{/if}}
 
                                                     {{#if this.example}}
                                                         <p><strong>Example</strong>:</p>
-                                                        <pre><code>{{this.example}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                     {{/if}}
                                                 {{/each}}
                                             {{/if}}

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -123,7 +123,7 @@
 
                                                 {{#if this.example}}
                                                     <p><strong>Example</strong>:</p>
-                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.example}}</code></pre>
                                                 {{/if}}
                                             {{/each}}
                                         {{/if}}
@@ -157,7 +157,7 @@
 
                                                     {{#if this.example}}
                                                         <p><strong>Example</strong>:</p>
-                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.example}}</code></pre>
                                                     {{/if}}
                                                 {{/each}}
                                             {{/if}}


### PR DESCRIPTION
This includes support for more readable formatting of JSON schemas and examples for request and response entity data.  Though this formatting could be done directly in the RAML file itself, there are cases when RAML is auto-generated by tools that don't regard RAML as a presentation format (and therefore just run everything together).

This includes examples/checkers.raml, which demonstrates the feature.