### PR TITLE
Add support for documenting "traits" (issue #124).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.iml
+.idea
 
 pids
 logs

--- a/examples/checkers.raml
+++ b/examples/checkers.raml
@@ -1,0 +1,35 @@
+#%RAML 0.8
+---
+title: Checkers
+version: v1
+baseUri: /api/v1
+documentation:
+    - title: Overview
+      content: |
+           Draughts (/ˈdrɑːfts/, British English) or checkers (American English) is a group of strategy board games for 
+           two players which involve diagonal moves of uniform game pieces and mandatory captures by jumping over opponent 
+           pieces. Draughts developed from alquerque. The name derives from the verb to draw or to move.
+          
+/api/v1:
+    uriParameters:
+    /checkers/games:
+        uriParameters:
+        get:
+            description: |
+                 Retrieves a collection of existing games from the server.
+                
+            queryParameters:
+                state:
+                    description:  Filters the selection on state.
+                    type: string
+                    enum: [ STARTING, ACTIVE, PAUSED, ENDED ]
+
+            responses:
+                200:
+                    body:
+                        application/json:
+                            schema: |
+                                {"type":"object","id":"urn:jsonschema:org:madpolicy:dto:GameCollection","properties":{"games":{"type":"array","items":{"type":"object","id":"urn:jsonschema:org:madpolicy:dto:Game","properties":{"gameboard":{"type":"array","required":true,"description":"The state of the gameboard.","items":{"type":"array","items":{"type":"string","enum":["ToString:RED","ToString:BLACK","ToString:FREE"]}}},"name":{"type":"string","description":"Name of the game."}}}}}}
+                            example: |
+                                {"games": [{"name": "string","gameboard": "string one of [RED,BLACK,FREE]"}]}
+

--- a/examples/traits.raml
+++ b/examples/traits.raml
@@ -1,0 +1,31 @@
+#%RAML 0.8
+---
+title: Traits
+version: v1
+baseUri: /api/v1
+documentation:
+    - title: Overview
+      content: An API to illustrate documentation of traits.
+
+traits:
+    - experimental:
+        description: This endpoint is experimental.
+    - stable:
+        description: This endpoint is stable.
+    - deprecated:
+        description: This endpoint is deprecated.
+
+
+/traits/widgets:
+    uriParameters:
+    get:
+        description: Retrieves a collection of widgets.
+        is: [ stable]
+
+    post:
+        description: Create a new widget.
+        is: [ deprecated]
+
+    patch:
+        description: Modify a widget.
+        is: [ experimental]

--- a/examples/traits.raml
+++ b/examples/traits.raml
@@ -14,6 +14,8 @@ traits:
         description: This endpoint is stable.
     - deprecated:
         description: This endpoint is deprecated.
+    - hunger:
+        description: This endpoint will end world hunger.
 
 
 /traits/widgets:
@@ -28,4 +30,4 @@ traits:
 
     patch:
         description: Modify a widget.
-        is: [ experimental]
+        is: [ experimental, hunger]

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -43,27 +43,12 @@ function _lockIconHelper(securedBy) {
     return '';
 }
 
-function _traitsIconHelper(trait) {
-    var traitIcons = {
-        stable: "glyphicon-ok-sign",
-        experimental: "glyphicon-question-sign",
-        deprecated: "glyphicon-remove-sign"
-    };
-
-    var traitIcon = traitIcons[trait];
-    if (!traitIcon) {
-        traitIcon = "glyphicon-tag";
-    }
-
-    return '<span class="glyphicon ' + traitIcon + '" title="' + trait + '"></span>';
-}
-
 function _traitsHelper(traits, is) {
     var retval = '';
     for (var trait in is) {
         for (var traitdesc in traits) {
             if (traits[traitdesc].hasOwnProperty(is[trait])) {
-                retval += _traitsIconHelper(is[trait]);
+                retval += '<span class="glyphicon glyphicon-tag" title="' + is[trait] + '"></span>';
                 retval += ' ' + traits[traitdesc][is[trait]].description + '<br/>';
             }
         }

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -69,6 +69,13 @@ function _ifTypeIsString(options) {
     }
 }
 
+function _prettyPrint(type, schema) {
+    if (type === "application/json") {
+        return JSON.stringify(JSON.parse(schema), null, " ");
+    }
+    return schema;
+}
+
 /*
  The config object can contain the following keys and values:
  template: string or Handlebars object containing the main template (required)
@@ -134,7 +141,8 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
             missingRequestCheckHelper: _missingRequestCheckHelper,
             md: _markDownHelper,
             lock: _lockIconHelper,
-            ifTypeIsString: _ifTypeIsString
+            ifTypeIsString: _ifTypeIsString,
+            prettyPrint: _prettyPrint
         },
         partials: {
             resource: resourceTemplate,

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -43,12 +43,28 @@ function _lockIconHelper(securedBy) {
     return '';
 }
 
+function _traitsIconHelper(trait) {
+    var traitIcons = {
+        stable: "glyphicon-ok-sign",
+        experimental: "glyphicon-question-sign",
+        deprecated: "glyphicon-remove-sign"
+    };
+
+    var traitIcon = traitIcons[trait];
+    if (!traitIcon) {
+        traitIcon = "glyphicon-tag";
+    }
+
+    return '<span class="glyphicon ' + traitIcon + '" title="experimental"></span>';
+}
+
 function _traitsHelper(traits, is) {
     var retval = '';
     for (var trait in is) {
         for (var traitdesc in traits) {
             if (traits[traitdesc].hasOwnProperty(is[trait])) {
-                retval += ' <span class="glyphicon glyphicon-tag" title="trait"></span> ' + traits[traitdesc][is[trait]].description + '<br/>';
+                retval += _traitsIconHelper(is[trait]);
+                retval += ' ' + traits[traitdesc][is[trait]].description + '<br/>';
             }
         }
     }

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -43,6 +43,18 @@ function _lockIconHelper(securedBy) {
     return '';
 }
 
+function _traitsHelper(traits, is) {
+    var retval = '';
+    for (var trait in is) {
+        for (var traitdesc in traits) {
+            if (traits[traitdesc].hasOwnProperty(is[trait])) {
+                retval += ' <span class="glyphicon glyphicon-tag" title="trait"></span> ' + traits[traitdesc][is[trait]].description + '<br/>';
+            }
+        }
+    }
+    return new handlebars.SafeString(retval);
+}
+
 function _emptyResourceCheckHelper(options) {
     if (this.methods || (this.description && this.parentUrl)) {
 	    return options.fn(this);
@@ -142,7 +154,8 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
             md: _markDownHelper,
             lock: _lockIconHelper,
             ifTypeIsString: _ifTypeIsString,
-            prettyPrint: _prettyPrint
+            prettyPrint: _prettyPrint,
+            traitsHelper: _traitsHelper
         },
         partials: {
             resource: resourceTemplate,

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -55,7 +55,7 @@ function _traitsIconHelper(trait) {
         traitIcon = "glyphicon-tag";
     }
 
-    return '<span class="glyphicon ' + traitIcon + '" title="experimental"></span>';
+    return '<span class="glyphicon ' + traitIcon + '" title="' + trait + '"></span>';
 }
 
 function _traitsHelper(traits, is) {

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -118,12 +118,12 @@
 
                                                 {{#if this.schema}}
                                                     <p><strong>Schema</strong>:</p>
-                                                    <pre><code>{{this.schema}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                 {{/if}}
 
                                                 {{#if this.example}}
                                                     <p><strong>Example</strong>:</p>
-                                                    <pre><code>{{this.example}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                 {{/if}}
                                             {{/each}}
                                         {{/if}}
@@ -152,12 +152,12 @@
 
                                                     {{#if this.schema}}
                                                         <p><strong>Schema</strong>:</p>
-                                                        <pre><code>{{this.schema}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                     {{/if}}
 
                                                     {{#if this.example}}
                                                         <p><strong>Example</strong>:</p>
-                                                        <pre><code>{{this.example}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
                                                     {{/if}}
                                                 {{/each}}
                                             {{/if}}

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -123,7 +123,7 @@
 
                                                 {{#if this.example}}
                                                     <p><strong>Example</strong>:</p>
-                                                    <pre><code>{{prettyPrint @key this.schema}}</code></pre>
+                                                    <pre><code>{{prettyPrint @key this.example}}</code></pre>
                                                 {{/if}}
                                             {{/each}}
                                         {{/if}}
@@ -157,7 +157,7 @@
 
                                                     {{#if this.example}}
                                                         <p><strong>Example</strong>:</p>
-                                                        <pre><code>{{prettyPrint @key this.schema}}</code></pre>
+                                                        <pre><code>{{prettyPrint @key this.example}}</code></pre>
                                                     {{/if}}
                                                 {{/each}}
                                             {{/if}}

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -57,6 +57,12 @@
                                 </div>
                             {{/if}}
 
+                            {{#if is}}
+                                <div class="alert alert-warning">
+                                    {{traitsHelper ../../../traits is}}
+                                </div>
+                            {{/if}}
+
                             <!-- Nav tabs -->
                             <ul class="nav nav-tabs">
                                 {{#emptyRequestCheckHelper}}
@@ -174,5 +180,5 @@
 {{/emptyResourceCheck}}
 
 {{#resources}}
-    {{> resource}}
+    {{> resource traits=traits}}
 {{/resources}}

--- a/lib/template.handlebars
+++ b/lib/template.handlebars
@@ -164,8 +164,7 @@
                                     {{md description}}
                                 </div>
                             {{/if}}
-
-                            <div class="panel-group">{{> resource}}</div>
+                            <div class="panel-group">{{> resource traits=../this/traits}}</div>
                         </div>
                     </div>
                 {{/resources}}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "commander": "2.2.x",
-    "handlebars": "1.3.x",
+    "handlebars": "2.0.x",
     "marked": "0.3.x",
     "minimize": "0.8.x",
     "raml2obj": "1.0.x"


### PR DESCRIPTION
Taking another stab at this :).  The description of a trait is actually captured in the RAML itself, the tricky part was just making the top-level traits object visible within the recursive handlebars partial.  This unfortunately required bumping the handlbars dependency to 2.0.x.  

An example is provided in examples/traits.raml.

