### PR TITLE
Add support for documenting "traits" (issue #124).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.iml
+.idea
 
 pids
 logs

--- a/examples/traits.raml
+++ b/examples/traits.raml
@@ -31,3 +31,15 @@ traits:
     patch:
         description: Modify a widget.
         is: [ experimental, hunger]
+
+    /{id}:
+        uriParameters:
+        get:
+            description: Retrieves a widget.
+            is: [ stable]
+
+        /colors:
+            uriParameters:
+            get:
+                description: Retrieves a widget's colors.
+                is: [ deprecated]

--- a/examples/traits.raml
+++ b/examples/traits.raml
@@ -1,0 +1,33 @@
+#%RAML 0.8
+---
+title: Traits
+version: v1
+baseUri: /api/v1
+documentation:
+    - title: Overview
+      content: An API to illustrate documentation of traits.
+
+traits:
+    - experimental:
+        description: This endpoint is experimental.
+    - stable:
+        description: This endpoint is stable.
+    - deprecated:
+        description: This endpoint is deprecated.
+    - hunger:
+        description: This endpoint will end world hunger.
+
+
+/traits/widgets:
+    uriParameters:
+    get:
+        description: Retrieves a collection of widgets.
+        is: [ stable]
+
+    post:
+        description: Create a new widget.
+        is: [ deprecated]
+
+    patch:
+        description: Modify a widget.
+        is: [ experimental, hunger]

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -43,6 +43,19 @@ function _lockIconHelper(securedBy) {
     return '';
 }
 
+function _traitsHelper(traits, is) {
+    var retval = '';
+    for (var trait in is) {
+        for (var traitdesc in traits) {
+            if (traits[traitdesc].hasOwnProperty(is[trait])) {
+                retval += '<span class="glyphicon glyphicon-tag" title="' + is[trait] + '"></span>';
+                retval += ' ' + traits[traitdesc][is[trait]].description + '<br/>';
+            }
+        }
+    }
+    return new handlebars.SafeString(retval);
+}
+
 function _emptyResourceCheckHelper(options) {
     if (this.methods || (this.description && this.parentUrl)) {
 	    return options.fn(this);
@@ -134,7 +147,8 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
             missingRequestCheckHelper: _missingRequestCheckHelper,
             md: _markDownHelper,
             lock: _lockIconHelper,
-            ifTypeIsString: _ifTypeIsString
+            ifTypeIsString: _ifTypeIsString,
+            traitsHelper: _traitsHelper
         },
         partials: {
             resource: resourceTemplate,

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -180,5 +180,5 @@
 {{/emptyResourceCheck}}
 
 {{#resources}}
-    {{> resource traits=traits}}
+    {{> resource traits=../this/traits}}
 {{/resources}}

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -57,6 +57,12 @@
                                 </div>
                             {{/if}}
 
+                            {{#if is}}
+                                <div class="alert alert-warning">
+                                    {{traitsHelper ../../../traits is}}
+                                </div>
+                            {{/if}}
+
                             <!-- Nav tabs -->
                             <ul class="nav nav-tabs">
                                 {{#emptyRequestCheckHelper}}
@@ -174,5 +180,5 @@
 {{/emptyResourceCheck}}
 
 {{#resources}}
-    {{> resource}}
+    {{> resource traits=traits}}
 {{/resources}}

--- a/lib/template.handlebars
+++ b/lib/template.handlebars
@@ -164,8 +164,7 @@
                                     {{md description}}
                                 </div>
                             {{/if}}
-
-                            <div class="panel-group">{{> resource}}</div>
+                            <div class="panel-group">{{> resource traits=../this/traits}}</div>
                         </div>
                     </div>
                 {{/resources}}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "commander": "2.2.x",
-    "handlebars": "1.3.x",
+    "handlebars": "2.0.x",
     "marked": "0.3.x",
     "minimize": "0.8.x",
     "raml2obj": "1.0.x"


### PR DESCRIPTION
Taking another stab at this :). The description of a trait is actually captured in the RAML itself, the tricky part was just making the top-level traits object visible within the recursive handlebars partial. This unfortunately required bumping the handlbars dependency to 2.0.x.

An example is provided in examples/traits.raml.