### PR TITLE
Use RFC 1808 hrefs/src instead of config.protocol

### DIFF
--- a/lib/template.handlebars
+++ b/lib/template.handlebars
@@ -6,11 +6,11 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="generator" content="https://github.com/kevinrenskers/raml2html {{config.raml2HtmlVersion}}">
 
-    <link rel="stylesheet" href="{{config.protocol}}//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{config.protocol}}//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/default.min.css">
-    <script type="text/javascript" src="{{config.protocol}}//code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="{{config.protocol}}//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="{{config.protocol}}//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js"></script>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/default.min.css">
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js"></script>
 
     <script type="text/javascript">
         $(document).ready(function() {


### PR DESCRIPTION
Per RFC 1808, double-slash at the start of href or src will automatically match
the protocol of the parent document so there is no need to explicitly specify a
protocol.