### PR TITLE
Fix typo preventing header items being rendered

### DIFF
--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -96,7 +96,7 @@
                     {% if method.headers %}
                       <h3>Headers</h3>
                       <ul>
-                        {% for key, item in headers %}
+                        {% for key, item in method.headers %}
                           {% include "item.nunjucks" %}
                         {% endfor %}
                       </ul>


### PR DESCRIPTION
It seems this should have read `method.headers` instead of just `headers`. Making this changes causes header items to be rendered again.