### PR TITLE
marked renderer overriding and some ESLint fixes.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -124,7 +124,7 @@
     "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
     "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
     "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
-    "no-wrap-func": 2,               // http://eslint.org/docs/rules/no-wrap-func
+    "no-extra-parens": 2,               // http://eslint.org/docs/rules/no-wrap-func
     "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
     "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
     "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
@@ -138,6 +138,6 @@
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
-    "spaced-line-comment": 2         // http://eslint.org/docs/rules/spaced-line-comment
+    "spaced-comment": 2         // http://eslint.org/docs/rules/spaced-line-comment
   }
 }

--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       // Setup the Nunjucks environment with the markdown parser
       var env = nunjucks.configure(templatesPath, {watch: false});
-      markdown.register(env, marked);
+      markdown.register(env, function(md) {
+        return marked(md, {renderer: renderer});
+      });
 
       // Add extra function for finding a security scheme by name
       ramlObj.securitySchemeWithName = function(name) {


### PR DESCRIPTION
#### marked renderer methods
The way marked was called to render the Markdown didn't take overridden renderer methods into account. As of now, this was only the renderer.table method which was intended to render Bootstrap style tables.
#### ESLint
I replaced some... well... replaced ESLint rules.